### PR TITLE
Clip! Clip! Clip!

### DIFF
--- a/src/classes/Canvas.py
+++ b/src/classes/Canvas.py
@@ -92,5 +92,5 @@ class Canvas(Item):
             elif isinstance(other, Text):
                 # get font from text and add to defs
                 self.defs_map[other.font.family] = other.font.defs()
-            elif isinstance(other, Shape) and other.clipped == True:
+            elif isinstance(other, Shape) and other.clip != None:
                 self.defs_map[id(other)] = other.defs()

--- a/src/classes/Clip.py
+++ b/src/classes/Clip.py
@@ -1,0 +1,9 @@
+class Clip(object):
+    def __init__(self, clipped_in : bool=True):
+        self.clipped_in = clipped_in
+
+    def is_inner(self):
+        return self.clipped_in
+
+    def is_outer(self):
+        return not self.clipped_in

--- a/src/classes/Item.py
+++ b/src/classes/Item.py
@@ -32,12 +32,15 @@ class Item(object):
     def render(self) -> str:
         raise NotImplementedError
 
-    def render_children(self) -> str:
+    def render_children(self, mask=False) -> str:
         # Start group for children
         s = ('\t' * self.depth) + f'<g transform="translate({self.position.x}, {self.position.y})"'
         # Check if clipped
-        if self.clipped == True:
-            s += f' style="clip-path: url(#{id(self)});"'
+        if self.clip != None:
+            if not mask:
+                s += f' style="clip-path: url(#{id(self)});"'
+            else:
+                s += f' style="mask: url(#{id(self)});"'
         s += '>\n'
         for child in self.children:
             s += ('\t' * (self.depth + 1)) + child.render() + '\n'

--- a/src/classes/primitives/Circle.py
+++ b/src/classes/primitives/Circle.py
@@ -1,6 +1,7 @@
 from typing import Union, Optional, Iterable
 from ..Stroke import Stroke
 from ..Fill import Fill
+from ..Clip import Clip
 from ..Item import Item
 from .Shape import Shape
 from ..util.Vector2 import Vector2
@@ -12,12 +13,12 @@ class Circle(Shape):
     """
     # create circle as an ellipse with same x and y radius
     def __init__(self,
-            clipped: bool, position: Vector2,
+            clip: Clip, position: Vector2,
             radius: Union[int, float],
             stroke: Optional[Stroke] = None, fill: Optional[Fill] = None,
             children: Iterable[Item] = [], rotation: Union[int, float] = 0
         ):
-        super().__init__(clipped, position,
+        super().__init__(clip, position,
                          stroke=stroke, fill=fill,
                          children=children, rotation=rotation)
         self.radius: Union[int, float] = radius
@@ -33,6 +34,8 @@ class Circle(Shape):
             s += ' ' + self.stroke.render()
         if self.fill != None:
             s += ' ' + self.fill.render()
+        else:
+            s += ' ' + 'fill="#000000" fill-opacity="0.0"'
         s += ' />'
         # Render Children
         if len(self.children) > 0:
@@ -44,7 +47,10 @@ class Circle(Shape):
         # Create defs
         s = super().defs()
         stroke_width = 0 if self.stroke == None else self.stroke.width
-        s += f'<circle cx="-{self.position.x}" cy="-{self.position.y}" r="{self.radius+stroke_width}"'
+        if self.clip != None and self.clip.is_inner():
+            s += f'<circle cx="0" cy="0" r="{self.radius-stroke_width//2}"'
+        elif self.clip != None and self.clip.is_outer():
+            s += f'<circle cx="0" cy="0" r="{self.radius+stroke_width//2+1}"'
         # Apply rotation if needed
         if abs(self.rotation) > 1e-6:
             s += f' transform="rotate({self.rotation})"'

--- a/src/classes/primitives/Circle.py
+++ b/src/classes/primitives/Circle.py
@@ -48,7 +48,7 @@ class Circle(Shape):
         s = super().defs()
         stroke_width = 0 if self.stroke == None else self.stroke.width
         if self.clip != None and self.clip.is_inner():
-            s += f'<circle cx="0" cy="0" r="{self.radius-stroke_width//2}"'
+            s += f'<circle cx="0" cy="0" r="{self.radius}"'
         elif self.clip != None and self.clip.is_outer():
             s += f'<circle cx="0" cy="0" r="{self.radius+stroke_width//2+1}"'
         # Apply rotation if needed

--- a/src/classes/primitives/Circle.py
+++ b/src/classes/primitives/Circle.py
@@ -43,7 +43,8 @@ class Circle(Shape):
     def defs(self) -> str:
         # Create defs
         s = super().defs()
-        s += f'<circle cx="-{self.position.x}" cy="-{self.position.y}" r="{self.radius}"'
+        stroke_width = 0 if self.stroke == None else self.stroke.width
+        s += f'<circle cx="-{self.position.x}" cy="-{self.position.y}" r="{self.radius+stroke_width}"'
         # Apply rotation if needed
         if abs(self.rotation) > 1e-6:
             s += f' transform="rotate({self.rotation})"'

--- a/src/classes/primitives/Ellipse.py
+++ b/src/classes/primitives/Ellipse.py
@@ -46,7 +46,8 @@ class Ellipse(Shape):
     def defs(self) -> str:
         # Create defs
         s = super().defs()
-        s += f'<ellipse cx="-{self.position.x}" cy="-{self.position.y}" rx="{self.rx}" ry="{self.ry}"'
+        stroke_width = 0 if self.stroke == None else self.stroke.width
+        s += f'<ellipse cx="-{self.position.x}" cy="-{self.position.y}" rx="{self.rx+stroke_width}" ry="{self.ry+stroke_width}"'
         # Apply rotation if needed
         if abs(self.rotation) > 1e-6:
             s += f' transform="rotate({self.rotation})"'

--- a/src/classes/primitives/Ellipse.py
+++ b/src/classes/primitives/Ellipse.py
@@ -2,6 +2,7 @@ from typing import Union, Optional, Iterable
 from ..Stroke import Stroke
 from ..Fill import Fill
 from ..Item import Item
+from ..Clip import Clip
 from .Shape import Shape
 from ..util.Vector2 import Vector2
 
@@ -14,12 +15,12 @@ class Ellipse(Shape):
     # create circle as an ellipse with same x and y radius
 
     def __init__(self,
-                 clipped: bool, position: Vector2,
+                 clip: Clip, position: Vector2,
                  rx: Union[int, float], ry: Union[int, float],
                  stroke: Optional[Stroke] = None, fill: Optional[Fill] = None,
                  children: Iterable[Item] = [], rotation: Union[int, float] = 0
                  ):
-        super().__init__(clipped, position,
+        super().__init__(clip, position,
                          stroke=stroke, fill=fill,
                          children=children, rotation=rotation)
         self.rx: Union[int, float] = rx
@@ -36,6 +37,8 @@ class Ellipse(Shape):
             s += ' ' + self.stroke.render()
         if self.fill != None:
             s += ' ' + self.fill.render()
+        else:
+            s += ' ' + 'fill="#000000" fill-opacity="0.0"'
         s += ' />'
         # Render Children
         if len(self.children) > 0:
@@ -47,7 +50,10 @@ class Ellipse(Shape):
         # Create defs
         s = super().defs()
         stroke_width = 0 if self.stroke == None else self.stroke.width
-        s += f'<ellipse cx="-{self.position.x}" cy="-{self.position.y}" rx="{self.rx+stroke_width}" ry="{self.ry+stroke_width}"'
+        if self.clip != None and self.clip.is_inner():
+            s += f'<ellipse cx="0" cy="0" rx="{self.rx-stroke_width//2}" ry="{self.ry-stroke_width//2}"'
+        elif self.clip != None and self.clip.is_outer():
+            s += f'<ellipse cx="0" cy="0" rx="{self.rx+stroke_width//2+1}" ry="{self.ry+stroke_width//2+1}"'
         # Apply rotation if needed
         if abs(self.rotation) > 1e-6:
             s += f' transform="rotate({self.rotation})"'

--- a/src/classes/primitives/Ellipse.py
+++ b/src/classes/primitives/Ellipse.py
@@ -51,7 +51,7 @@ class Ellipse(Shape):
         s = super().defs()
         stroke_width = 0 if self.stroke == None else self.stroke.width
         if self.clip != None and self.clip.is_inner():
-            s += f'<ellipse cx="0" cy="0" rx="{self.rx-stroke_width//2}" ry="{self.ry-stroke_width//2}"'
+            s += f'<ellipse cx="0" cy="0" rx="{self.rx}" ry="{self.ry}"'
         elif self.clip != None and self.clip.is_outer():
             s += f'<ellipse cx="0" cy="0" rx="{self.rx+stroke_width//2+1}" ry="{self.ry+stroke_width//2+1}"'
         # Apply rotation if needed

--- a/src/classes/primitives/Line.py
+++ b/src/classes/primitives/Line.py
@@ -2,18 +2,19 @@ from typing import Union, Optional, Iterable
 from ..Stroke import Stroke
 from ..Fill import Fill
 from ..Item import Item
+from ..Clip import Clip
 from .Shape import Shape
 from ..util.Vector2 import Vector2
 
 class Line(Shape):
     def __init__(self,
-            clipped: bool,
+            clip: Clip,
             start: Vector2, end: Vector2,
             stroke: Stroke,
             children: Iterable[Item] = [], rotation: Union[int, float] = 0
         ):
         position = (end - start) * 2 + start
-        super().__init__(clipped, position,
+        super().__init__(clip, position,
                          stroke=stroke, fill=None,
                          children=children, rotation=rotation)
         self.start: Vector2 = start

--- a/src/classes/primitives/Polygon.py
+++ b/src/classes/primitives/Polygon.py
@@ -2,6 +2,7 @@ from typing import Union, Optional, Iterable
 from ..Stroke import Stroke
 from ..Fill import Fill
 from ..Item import Item
+from ..Clip import Clip
 from .Shape import Shape
 from ..util.Vector2 import Vector2
 
@@ -14,7 +15,7 @@ class Polygon(Shape):
     # create circle as an ellipse with same x and y radius
 
     def __init__(self,
-                 clipped: bool,
+                 clip: Clip,
                  points: Iterable[Vector2],
                  stroke: Optional[Stroke] = None, fill: Optional[Fill] = None,
                  children: Iterable[Item] = [], rotation: Union[int, float] = 0
@@ -27,7 +28,7 @@ class Polygon(Shape):
         center.x /= len(points)
         center.y /= len(points)
         # set position to center
-        super().__init__(clipped, center,
+        super().__init__(clip, center,
                         stroke=stroke, fill=fill,
                         children=children, rotation=rotation)
         self.points = points
@@ -50,6 +51,8 @@ class Polygon(Shape):
             s += ' ' + self.stroke.render()
         if self.fill != None:
             s += ' ' + self.fill.render()
+        else:
+            s += ' ' + 'fill="#000000" fill-opacity="0.0"'
         s += ' />'
         # Render Children
         if len(self.children) > 0:
@@ -66,6 +69,7 @@ class Polygon(Shape):
             if index != len(self.points) - 1:
                 s += ' '
         s += '" '
+        
         # Apply translation for map since it is relative to parent:
         s += f' transform="translate(-{self.position.x}, -{self.position.y})"'
         # Apply rotation if needed

--- a/src/classes/primitives/Rect.py
+++ b/src/classes/primitives/Rect.py
@@ -52,7 +52,7 @@ class Rect(Shape):
         if self.clip != None and self.clip.is_inner():
             s += f'<rect x="{-(self.width // 2) + (stroke_width // 2)}" y="{-(self.height // 2) + (stroke_width // 2)}" width="{self.width - stroke_width}" height="{self.height - stroke_width}"'
         elif self.clip != None and self.clip.is_outer():
-            s += f'<rect x="{-(self.width // 2) - (stroke_width // 2)-1}" y="{-(self.height // 2) - (stroke_width // 2)-1}" width="{self.width + stroke_width+2}" height="{self.height + stroke_width}+2"'
+            s += f'<rect x="{-(self.width // 2) - (stroke_width // 2)-1}" y="{-(self.height // 2) - (stroke_width // 2)-1}" width="{self.width + stroke_width+2}" height="{self.height + stroke_width+2}"'
         # Apply rotation if needed
         if abs(self.rotation) > 1e-6:
             s += f' transform="rotate({self.rotation})"'

--- a/src/classes/primitives/Rect.py
+++ b/src/classes/primitives/Rect.py
@@ -37,6 +37,8 @@ class Rect(Shape):
             s += ' ' + self.stroke.render()
         if self.fill != None:
             s += ' ' + self.fill.render()
+        else:
+            s += ' ' + 'fill="#000000" fill-opacity="0.0"'
         s += ' />'
         # Render Children
         if len(self.children) > 0:
@@ -46,7 +48,7 @@ class Rect(Shape):
 
     def defs(self) -> str:
         s = super().defs()
-        s += f'<rect x="-{self.position.x}" y="-{self.position.y}" width="{self.width}" height="{self.height}"'
+        s += f'<rect x="-{self.width // 2}" y="-{self.height // 2}" width="{self.width}" height="{self.height}"'
         # Apply rotation if needed
         if abs(self.rotation) > 1e-6:
             s += f' transform="rotate({self.rotation})"'

--- a/src/classes/primitives/Rect.py
+++ b/src/classes/primitives/Rect.py
@@ -50,7 +50,7 @@ class Rect(Shape):
         s = super().defs()
         stroke_width = 0 if self.stroke == None else self.stroke.width
         if self.clip != None and self.clip.is_inner():
-            s += f'<rect x="{-(self.width // 2) + (stroke_width // 2)}" y="{-(self.height // 2) + (stroke_width // 2)}" width="{self.width - stroke_width}" height="{self.height - stroke_width}"'
+            s += f'<rect x="{-(self.width // 2)}" y="{-(self.height // 2)}" width="{self.width}" height="{self.height}"'
         elif self.clip != None and self.clip.is_outer():
             s += f'<rect x="{-(self.width // 2) - (stroke_width // 2)-1}" y="{-(self.height // 2) - (stroke_width // 2)-1}" width="{self.width + stroke_width+2}" height="{self.height + stroke_width+2}"'
         # Apply rotation if needed

--- a/src/classes/primitives/Rect.py
+++ b/src/classes/primitives/Rect.py
@@ -52,7 +52,7 @@ class Rect(Shape):
         if self.clip != None and self.clip.is_inner():
             s += f'<rect x="{-(self.width // 2) + (stroke_width // 2)}" y="{-(self.height // 2) + (stroke_width // 2)}" width="{self.width - stroke_width}" height="{self.height - stroke_width}"'
         elif self.clip != None and self.clip.is_outer():
-            s += f'<rect x="{-(self.width // 2) - (stroke_width // 2)-1}" y="{-(self.height // 2) - (stroke_width // 2)-1}" width="{self.width + stroke_width}+2" height="{self.height + stroke_width}+2"'
+            s += f'<rect x="{-(self.width // 2) - (stroke_width // 2)-1}" y="{-(self.height // 2) - (stroke_width // 2)-1}" width="{self.width + stroke_width+2}" height="{self.height + stroke_width}+2"'
         # Apply rotation if needed
         if abs(self.rotation) > 1e-6:
             s += f' transform="rotate({self.rotation})"'

--- a/src/classes/primitives/Rect.py
+++ b/src/classes/primitives/Rect.py
@@ -13,12 +13,12 @@ class Rect(Shape):
     - cy = y - height//2
     """
     def __init__(self,
-            clipped: bool, position: Vector2,
+            clip: bool, position: Vector2,
             width: Union[int, float], height: Union[int, float],
             stroke: Optional[Stroke] = None, fill: Optional[Fill] = None,
             children: Iterable[Item] = [], rotation: Union[int, float] = 0
         ):
-        super().__init__(clipped, position,
+        super().__init__(clip, position,
                          stroke=stroke, fill=fill,
                          children=children, rotation=rotation)
         self.width: Union[int, float] = width
@@ -48,7 +48,11 @@ class Rect(Shape):
 
     def defs(self) -> str:
         s = super().defs()
-        s += f'<rect x="-{self.width // 2}" y="-{self.height // 2}" width="{self.width}" height="{self.height}"'
+        stroke_width = 0 if self.stroke == None else self.stroke.width
+        if self.clip != None and self.clip.is_inner():
+            s += f'<rect x="{-(self.width // 2) + (stroke_width // 2)}" y="{-(self.height // 2) + (stroke_width // 2)}" width="{self.width - stroke_width}" height="{self.height - stroke_width}"'
+        elif self.clip != None and self.clip.is_outer():
+            s += f'<rect x="{-(self.width // 2) - (stroke_width // 2)}" y="{-(self.height // 2) - (stroke_width // 2)}" width="{self.width + stroke_width}" height="{self.height + stroke_width}"'
         # Apply rotation if needed
         if abs(self.rotation) > 1e-6:
             s += f' transform="rotate({self.rotation})"'

--- a/src/classes/primitives/Rect.py
+++ b/src/classes/primitives/Rect.py
@@ -52,7 +52,7 @@ class Rect(Shape):
         if self.clip != None and self.clip.is_inner():
             s += f'<rect x="{-(self.width // 2) + (stroke_width // 2)}" y="{-(self.height // 2) + (stroke_width // 2)}" width="{self.width - stroke_width}" height="{self.height - stroke_width}"'
         elif self.clip != None and self.clip.is_outer():
-            s += f'<rect x="{-(self.width // 2) - (stroke_width // 2)}" y="{-(self.height // 2) - (stroke_width // 2)}" width="{self.width + stroke_width}" height="{self.height + stroke_width}"'
+            s += f'<rect x="{-(self.width // 2) - (stroke_width // 2)-1}" y="{-(self.height // 2) - (stroke_width // 2)-1}" width="{self.width + stroke_width}+2" height="{self.height + stroke_width}+2"'
         # Apply rotation if needed
         if abs(self.rotation) > 1e-6:
             s += f' transform="rotate({self.rotation})"'

--- a/src/classes/primitives/Shape.py
+++ b/src/classes/primitives/Shape.py
@@ -1,12 +1,13 @@
 from typing import Union, Optional, Iterable
 from ..Stroke import Stroke
 from ..Fill import Fill
+from ..Clip import Clip
 from ..Item import Item
 from ..util.Vector2 import Vector2
 
 class Shape(Item):
     def __init__(self,
-            clipped: bool, position: Vector2,
+            clip: Clip, position: Vector2,
             stroke: Optional[Stroke] = None, fill: Optional[Fill] = None,
             children: Iterable[Item] = [],
             rotation: Union[int, float] = 0
@@ -14,7 +15,7 @@ class Shape(Item):
         super().__init__(rotation)
         for child in children:
             self.add_child(child)
-        self.clipped: bool = clipped
+        self.clip: Clip = clip
         self.position: Vector2 = position
         self.stroke: Optional[Stroke] = stroke
         self.fill: Optional[Fill] = fill

--- a/src/global_grammar.lark
+++ b/src/global_grammar.lark
@@ -27,15 +27,17 @@ canvas_definition: "canvas" _INLINE_WHITESPACE file_name _INLINE_WHITESPACE size
 item: rect | circle | ellipse | line | polygon | text | image | custom
 
 color: identifier | hex_color
+clip: CLIP_TYPE
+CLIP_TYPE: "in" | "out"
 
 modifier_list: (modifier _INLINE_WHITESPACE)*
-modifier: STATIC_MODIFIER | outlined | rotated
+modifier: STATIC_MODIFIER | outlined | rotated | clipped
 STATIC_MODIFIER: "left"
     | "right"
     | "center"
-    | "clipped"
 outlined: "outlined" _INLINE_WHITESPACE color _INLINE_WHITESPACE thickness [_INLINE_WHITESPACE opacity]
 rotated: "rotated" _INLINE_WHITESPACE angle
+clipped: "clipped" [_INLINE_WHITESPACE clip]
 
 ?sum: product
     | sum "+" product         -> add

--- a/src/photex.py
+++ b/src/photex.py
@@ -71,7 +71,6 @@ class Parser:
 
             print("Done generating objects for '" + canvas.name + "'. Building output...")
 
-            # TODO: Build SVG!
             c = Canvas(canvas.base, canvas.ext.lower(), Vector2(canvas.width, canvas.height), canvas.children, 0)
             c.export()
 


### PR DESCRIPTION
# Changes In This Clippy Update

## Proper Clipping
Fixed clipping for:
- Rect
- Circle
- Ellipse
- Polygon
Performed basic tests for these, but did not try any crazy edge cases. You can make a clipped object by doing this:
```
clipped rect 0 0 300 300 { ... } // All items inside ... that overflow the rect boundaries will be cut off
```

## [New feature] Inner and Outer Clipping
I felt there was a need for two types of clipping when clipping an outlined object. This is due to the fact that you can either clip inside the stroke or outside the stroke and obtain a completely different effect. I explain the two types below with examples.

### Inner Clipping
One can "inner clip", or clip inside the stroke by writing code like the following:
```
clipped in outlined #FF0000 10 rect 0 0 300 300 {
        image 0 0 500 500 "scor.jpg"
}

// OR just

clipped outlined #FF0000 10 rect 0 0 300 300 {
        image 0 0 500 500 "scor.jpg"
}
```
Yielding something like: 
![Test](https://user-images.githubusercontent.com/11153746/139541228-5727130e-ae51-4c79-83bc-70dc3a404788.png)

### Inner Clipping
One can "outer clip", or clip outside the stroke by writing code like the following:
```
clipped out outlined #FF0000 10 rect 0 0 300 300 {
        image 0 0 500 500 "scor.jpg"
}
```
Yielding something more like this:
![Test](https://user-images.githubusercontent.com/11153746/139541259-d56b3461-4c49-4ee0-af51-994229f35950.png)

### An Important Note
Both inner and outer clipping work perfectly for circles, rectangles, and ellipses. But for custom polygons, clipping can be quite difficult, so as of now, only inner clipping is supported. I hope to work on this again in the future to add outer clipping for custom polygons.